### PR TITLE
Update CraftingIOBufferPartMachine.java

### DIFF
--- a/src/main/java/com/epimorphismmc/gregiceng/common/machine/multiblock/part/appeng/CraftingIOBufferPartMachine.java
+++ b/src/main/java/com/epimorphismmc/gregiceng/common/machine/multiblock/part/appeng/CraftingIOBufferPartMachine.java
@@ -213,7 +213,14 @@ public class CraftingIOBufferPartMachine extends MEPartMachine
 
         if (!isWorkingEnabled() && returnBuffer.isEmpty()) return;
 
+        if (returnBuffer == null) {
+            returnBuffer = new Object2LongOpenHashMap<>();
+            return;
+        }
+
         if (getMainNode().isActive() && !this.returnBuffer.isEmpty()) {
+            var grid = getMainNode().getGrid();
+            if (grid == null) return;
             MEStorage aeNetwork = this.getMainNode().getGrid().getStorageService().getInventory();
             var iterator = returnBuffer.object2LongEntrySet().fastIterator();
             while (iterator.hasNext()) {


### PR DESCRIPTION
修复在访问io总成时可能访问到空对象而引起游戏崩溃的bug（本人Java水平有限，但是玩了一段时间没报错也没吞材料）